### PR TITLE
Align with AGOF config-as-code naming and git auth (v0.2.3)

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -5,7 +5,7 @@ home: https://github.com/validatedpatterns/aap-config-chart.git
 keywords:
 - pattern
 name: aap-config
-version: 0.2.2
+version: 0.3.0
 dependencies:
 - name: vp-rbac
   version: '0.1.*'

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -5,7 +5,7 @@ home: https://github.com/validatedpatterns/aap-config-chart.git
 keywords:
 - pattern
 name: aap-config
-version: 0.3.0
+version: 0.2.3
 dependencies:
 - name: vp-rbac
   version: '0.1.*'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aap-config
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square)
 
 A Helm chart to build and deploy secrets using external-secrets for ansible-edge-gitops
 
@@ -33,7 +33,7 @@ jobs.
 * v0.2.2: Make agof-vault-file optional. Allow for skipping of the local Vault Hub
 instance integration if desired.
 
-* v0.3.0: Align with AGOF config-as-code naming and git authentication. Add
+* v0.2.3: Align with AGOF config-as-code naming and git authentication. Add
 `agof.cac_repo` / `agof.cac_revision` (preferred over legacy `iac_repo` /
 `iac_revision`). Git credential injection in init now covers both AGOF and the
 config-as-code repo URL. Requires a compatible AGOF revision (see agof README

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aap-config
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square)
 
 A Helm chart to build and deploy secrets using external-secrets for ansible-edge-gitops
 
@@ -32,6 +32,12 @@ jobs.
 
 * v0.2.2: Make agof-vault-file optional. Allow for skipping of the local Vault Hub
 instance integration if desired.
+
+* v0.3.0: Align with AGOF config-as-code naming and git authentication. Add
+`agof.cac_repo` / `agof.cac_revision` (preferred over legacy `iac_repo` /
+`iac_revision`). Git credential injection in init now covers both AGOF and the
+config-as-code repo URL. Requires a compatible AGOF revision (see agof README
+OpenShift section).
 
 ### VP-Secrets-v2
 
@@ -91,6 +97,8 @@ secrets:
 | agof.agof_repo | string | `"https://github.com/validatedpatterns/agof.git"` |  |
 | agof.agof_revision | string | `"v2"` |  |
 | agof.automationHubTokenKey | string | `"secret/data/hub/automation-hub-token"` |  |
+| agof.cac_repo | string | `""` |  |
+| agof.cac_revision | string | `""` |  |
 | agof.doAutoHubVaultConfig | bool | `true` |  |
 | agof.extraPlaybookOpts | string | `""` |  |
 | agof.gitAuthHttpsStyle | string | `"auto"` |  |

--- a/README.md
+++ b/README.md
@@ -39,6 +39,173 @@ instance integration if desired.
 config-as-code repo URL. Requires a compatible AGOF revision (see agof README
 OpenShift section).
 
+### Git authentication secret (`agof.gitAuthSecret`)
+
+When `agof_repo` or the config-as-code repo (`agof.cac_repo` / `agof.iac_repo`) is
+private, set `agof.gitAuthSecret` to the name of a Kubernetes Secret in the same
+namespace. The init container mounts that Secret and configures git before cloning
+AGOF. Use **one** authentication shape per Secret; the chart checks mechanisms in
+this order: `.git-credentials`, then `ssh-privatekey`, then HTTPS
+`username`/`password`/`token`.
+
+Pattern Helm values:
+
+```yaml
+agof:
+  gitAuthSecret: git-auth-secret
+  # Optional: populate the Secret from Vault via External Secrets (VP-Secrets-v2 below)
+  gitAuthVaultKey: secret/data/hub/git-auth-secret
+  # Used only for token-only HTTPS Secrets (see examples)
+  gitAuthHttpsStyle: auto   # auto | github | gitlab | gitea
+```
+
+#### HTTPS: pre-built `.git-credentials` store
+
+Secret key `.git-credentials` is copied to `~/.git-credentials` and used with
+`credential.helper store`. One line per host; credentials apply to both AGOF and
+the config-as-code repo when the host matches.
+
+VP-Secrets-v2:
+
+```yaml
+  - name: git-auth-secret
+    fields:
+    - name: .git-credentials
+      value: |
+        https://x-access-token:ghp_xxxxxxxxxxxxxxxxxxxx@github.com
+```
+
+Multiple hosts (GitLab, Forgejo, etc.):
+
+```yaml
+  - name: git-auth-secret
+    fields:
+    - name: .git-credentials
+      value: |
+        https://oauth2:glpat-xxxxxxxxxxxxxxxxxxxx@gitlab.com
+        https://my-gitea-user:0123456789abcdef0123456789abcdef01234567@forgejo.example.com
+```
+
+#### HTTPS: `username` + `password` or `token`
+
+The init container writes a git credential-store entry for each unique host parsed
+from `agof_repo` and the config-as-code repo URL.
+
+Username and password:
+
+```yaml
+  - name: git-auth-secret
+    fields:
+    - name: username
+      value: my-gitea-user
+    - name: password
+      value: my-secret-password
+```
+
+Username and token (PAT / deploy token):
+
+```yaml
+  - name: git-auth-secret
+    fields:
+    - name: username
+      value: x-access-token
+    - name: token
+      value: ghp_xxxxxxxxxxxxxxxxxxxx
+```
+
+#### HTTPS: `token` only
+
+When the Secret has a `token` key but no `username`, the chart picks the HTTPS
+username from `agof.gitAuthHttpsStyle` and the repo host (`auto`: GitHub → `git`,
+GitLab / Gitea / Forgejo / Codeberg → `oauth2`, otherwise `git`).
+
+GitHub PAT:
+
+```yaml
+agof:
+  gitAuthSecret: git-auth-secret
+  gitAuthVaultKey: secret/data/hub/git-auth-secret
+  gitAuthHttpsStyle: auto
+
+secrets:
+  - name: git-auth-secret
+    fields:
+    - name: token
+      value: ghp_xxxxxxxxxxxxxxxxxxxx
+```
+
+GitLab project or group access token:
+
+```yaml
+  - name: git-auth-secret
+    fields:
+    - name: token
+      value: glpat-xxxxxxxxxxxxxxxxxxxx
+```
+
+Force a platform username when `auto` does not match your host (for example a
+self-managed GitLab hostname):
+
+```yaml
+agof:
+  gitAuthSecret: git-auth-secret
+  gitAuthHttpsStyle: gitlab
+
+secrets:
+  - name: git-auth-secret
+    fields:
+    - name: token
+      value: glpat-xxxxxxxxxxxxxxxxxxxx
+```
+
+#### SSH: `ssh-privatekey` (+ optional `known_hosts`)
+
+Secret key `ssh-privatekey` is installed as `~/.ssh/id_rsa`. When `known_hosts` is
+present it is copied to `~/.ssh/known_hosts` and SSH uses strict host key
+checking. When `known_hosts` is omitted, SSH uses `StrictHostKeyChecking=accept-new`
+for the clone.
+
+Deploy key with pinned host key (recommended):
+
+```yaml
+  - name: git-auth-secret
+    fields:
+    - name: ssh-privatekey
+      path: /path/to/deploy_key   # or use value: with inline PEM/OpenSSH key
+    - name: known_hosts
+      value: |
+        github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI...
+      # obtain with: ssh-keyscan -t ed25519 github.com
+```
+
+Deploy key without `known_hosts` (accepts the host key on first connect):
+
+```yaml
+  - name: git-auth-secret
+    fields:
+    - name: ssh-privatekey
+      value: |
+        -----BEGIN OPENSSH PRIVATE KEY-----
+        ...
+        -----END OPENSSH PRIVATE KEY-----
+```
+
+Self-managed Forgejo / Gitea:
+
+```yaml
+  - name: git-auth-secret
+    fields:
+    - name: ssh-privatekey
+      path: /path/to/forgejo_deploy_key
+    - name: known_hosts
+      value: |
+        forgejo.example.com ssh-ed25519 AAAA...
+```
+
+You can also create the Secret directly (for example `kubernetes.io/ssh-auth`) as
+long as the data keys are `ssh-privatekey` and optionally `known_hosts`, and
+`agof.gitAuthSecret` points at that Secret name.
+
 ### VP-Secrets-v2
 
 ```yaml
@@ -64,21 +231,11 @@ secrets:
       path: 'full pathname of a valid agof_vault file for secrets to overlay the iac config'
       base64: true
 
-  # Optional, if git auth is needed
+  # Optional: private git auth for agof_repo and/or config-as-code repo (see section above)
   - name: git-auth-secret
     fields:
-    # HTTPS auth
-    - name: username
-      value: "Username to authenticate with"
-    - value: password
-      value: "Password to authenticate with"
-    # SSH auth
-    - name: .git-credentials
-      value: "git credentials"
-    - name: ssh-privatekey
-      value: "An ssh private key"
-    - name: known_hosts
-      value: "SSH known hosts for SSH authentication"
+    - name: token
+      value: ghp_xxxxxxxxxxxxxxxxxxxx
 ```
 
 **Homepage:** <https://github.com/validatedpatterns/aap-config-chart.git>

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -40,6 +40,173 @@ instance integration if desired.
 config-as-code repo URL. Requires a compatible AGOF revision (see agof README
 OpenShift section).
 
+### Git authentication secret (`agof.gitAuthSecret`)
+
+When `agof_repo` or the config-as-code repo (`agof.cac_repo` / `agof.iac_repo`) is
+private, set `agof.gitAuthSecret` to the name of a Kubernetes Secret in the same
+namespace. The init container mounts that Secret and configures git before cloning
+AGOF. Use **one** authentication shape per Secret; the chart checks mechanisms in
+this order: `.git-credentials`, then `ssh-privatekey`, then HTTPS
+`username`/`password`/`token`.
+
+Pattern Helm values:
+
+```yaml
+agof:
+  gitAuthSecret: git-auth-secret
+  # Optional: populate the Secret from Vault via External Secrets (VP-Secrets-v2 below)
+  gitAuthVaultKey: secret/data/hub/git-auth-secret
+  # Used only for token-only HTTPS Secrets (see examples)
+  gitAuthHttpsStyle: auto   # auto | github | gitlab | gitea
+```
+
+#### HTTPS: pre-built `.git-credentials` store
+
+Secret key `.git-credentials` is copied to `~/.git-credentials` and used with
+`credential.helper store`. One line per host; credentials apply to both AGOF and
+the config-as-code repo when the host matches.
+
+VP-Secrets-v2:
+
+```yaml
+  - name: git-auth-secret
+    fields:
+    - name: .git-credentials
+      value: |
+        https://x-access-token:ghp_xxxxxxxxxxxxxxxxxxxx@github.com
+```
+
+Multiple hosts (GitLab, Forgejo, etc.):
+
+```yaml
+  - name: git-auth-secret
+    fields:
+    - name: .git-credentials
+      value: |
+        https://oauth2:glpat-xxxxxxxxxxxxxxxxxxxx@gitlab.com
+        https://my-gitea-user:0123456789abcdef0123456789abcdef01234567@forgejo.example.com
+```
+
+#### HTTPS: `username` + `password` or `token`
+
+The init container writes a git credential-store entry for each unique host parsed
+from `agof_repo` and the config-as-code repo URL.
+
+Username and password:
+
+```yaml
+  - name: git-auth-secret
+    fields:
+    - name: username
+      value: my-gitea-user
+    - name: password
+      value: my-secret-password
+```
+
+Username and token (PAT / deploy token):
+
+```yaml
+  - name: git-auth-secret
+    fields:
+    - name: username
+      value: x-access-token
+    - name: token
+      value: ghp_xxxxxxxxxxxxxxxxxxxx
+```
+
+#### HTTPS: `token` only
+
+When the Secret has a `token` key but no `username`, the chart picks the HTTPS
+username from `agof.gitAuthHttpsStyle` and the repo host (`auto`: GitHub → `git`,
+GitLab / Gitea / Forgejo / Codeberg → `oauth2`, otherwise `git`).
+
+GitHub PAT:
+
+```yaml
+agof:
+  gitAuthSecret: git-auth-secret
+  gitAuthVaultKey: secret/data/hub/git-auth-secret
+  gitAuthHttpsStyle: auto
+
+secrets:
+  - name: git-auth-secret
+    fields:
+    - name: token
+      value: ghp_xxxxxxxxxxxxxxxxxxxx
+```
+
+GitLab project or group access token:
+
+```yaml
+  - name: git-auth-secret
+    fields:
+    - name: token
+      value: glpat-xxxxxxxxxxxxxxxxxxxx
+```
+
+Force a platform username when `auto` does not match your host (for example a
+self-managed GitLab hostname):
+
+```yaml
+agof:
+  gitAuthSecret: git-auth-secret
+  gitAuthHttpsStyle: gitlab
+
+secrets:
+  - name: git-auth-secret
+    fields:
+    - name: token
+      value: glpat-xxxxxxxxxxxxxxxxxxxx
+```
+
+#### SSH: `ssh-privatekey` (+ optional `known_hosts`)
+
+Secret key `ssh-privatekey` is installed as `~/.ssh/id_rsa`. When `known_hosts` is
+present it is copied to `~/.ssh/known_hosts` and SSH uses strict host key
+checking. When `known_hosts` is omitted, SSH uses `StrictHostKeyChecking=accept-new`
+for the clone.
+
+Deploy key with pinned host key (recommended):
+
+```yaml
+  - name: git-auth-secret
+    fields:
+    - name: ssh-privatekey
+      path: /path/to/deploy_key   # or use value: with inline PEM/OpenSSH key
+    - name: known_hosts
+      value: |
+        github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI...
+      # obtain with: ssh-keyscan -t ed25519 github.com
+```
+
+Deploy key without `known_hosts` (accepts the host key on first connect):
+
+```yaml
+  - name: git-auth-secret
+    fields:
+    - name: ssh-privatekey
+      value: |
+        -----BEGIN OPENSSH PRIVATE KEY-----
+        ...
+        -----END OPENSSH PRIVATE KEY-----
+```
+
+Self-managed Forgejo / Gitea:
+
+```yaml
+  - name: git-auth-secret
+    fields:
+    - name: ssh-privatekey
+      path: /path/to/forgejo_deploy_key
+    - name: known_hosts
+      value: |
+        forgejo.example.com ssh-ed25519 AAAA...
+```
+
+You can also create the Secret directly (for example `kubernetes.io/ssh-auth`) as
+long as the data keys are `ssh-privatekey` and optionally `known_hosts`, and
+`agof.gitAuthSecret` points at that Secret name.
+
 ### VP-Secrets-v2
 
 ```yaml
@@ -65,21 +232,11 @@ secrets:
       path: 'full pathname of a valid agof_vault file for secrets to overlay the iac config'
       base64: true
 
-  # Optional, if git auth is needed
+  # Optional: private git auth for agof_repo and/or config-as-code repo (see section above)
   - name: git-auth-secret
     fields:
-    # HTTPS auth
-    - name: username
-      value: "Username to authenticate with"
-    - value: password
-      value: "Password to authenticate with"
-    # SSH auth
-    - name: .git-credentials
-      value: "git credentials"
-    - name: ssh-privatekey
-      value: "An ssh private key"
-    - name: known_hosts
-      value: "SSH known hosts for SSH authentication"
+    - name: token
+      value: ghp_xxxxxxxxxxxxxxxxxxxx
 ```
 
 {{ template "chart.homepageLine" . }}

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -34,6 +34,12 @@ jobs.
 * v0.2.2: Make agof-vault-file optional. Allow for skipping of the local Vault Hub
 instance integration if desired.
 
+* v0.3.0: Align with AGOF config-as-code naming and git authentication. Add
+`agof.cac_repo` / `agof.cac_revision` (preferred over legacy `iac_repo` /
+`iac_revision`). Git credential injection in init now covers both AGOF and the
+config-as-code repo URL. Requires a compatible AGOF revision (see agof README
+OpenShift section).
+
 ### VP-Secrets-v2
 
 ```yaml

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -34,7 +34,7 @@ jobs.
 * v0.2.2: Make agof-vault-file optional. Allow for skipping of the local Vault Hub
 instance integration if desired.
 
-* v0.3.0: Align with AGOF config-as-code naming and git authentication. Add
+* v0.2.3: Align with AGOF config-as-code naming and git authentication. Add
 `agof.cac_repo` / `agof.cac_revision` (preferred over legacy `iac_repo` /
 `iac_revision`). Git credential injection in init now covers both AGOF and the
 config-as-code repo URL. Requires a compatible AGOF revision (see agof README

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -30,7 +30,7 @@ initContainers:
           set -euo pipefail
           export GIT_TERMINAL_PROMPT=0
           agof_repo_url={{ $.Values.agof.agof_repo | quote }}
-          iac_repo_url={{ $.Values.agof.iac_repo | quote }}
+          config_repo_url={{ $.Values.agof.cac_repo | default $.Values.agof.iac_repo | quote }}
 {{- if $.Values.agof.vaultFileKey }}
           base64 -d /pattern-home/agof-vault-file/agof-vault-file > ~/agof_vault.yml
 {{- else }}
@@ -110,9 +110,9 @@ initContainers:
                 [[ -z "$host" ]] && continue
                 host_any=1
                 agof_https_store_credential "$host" "$u" "$p"
-              done < <(agof_unique_git_hosts "$agof_repo_url" "$iac_repo_url")
+              done < <(agof_unique_git_hosts "$agof_repo_url" "$config_repo_url")
               if [[ -z "$host_any" ]]; then
-                echo "agof.gitAuthSecret: could not parse git host from agof_repo or iac_repo for HTTPS credentials" >&2
+                echo "agof.gitAuthSecret: could not parse git host from agof_repo or config repo URL for HTTPS credentials" >&2
                 exit 1
               fi
             elif [[ -f "$GIT_AUTH_DIR/token" ]] && [[ ! -f "$GIT_AUTH_DIR/username" ]]; then
@@ -123,9 +123,9 @@ initContainers:
                 host_any=1
                 u="$(agof_https_user_for_style "$host" "$https_style")"
                 agof_https_store_credential "$host" "$u" "$p"
-              done < <(agof_unique_git_hosts "$agof_repo_url" "$iac_repo_url")
+              done < <(agof_unique_git_hosts "$agof_repo_url" "$config_repo_url")
               if [[ -z "$host_any" ]]; then
-                echo "agof.gitAuthSecret: could not parse git host from agof_repo or iac_repo for HTTPS token" >&2
+                echo "agof.gitAuthSecret: could not parse git host from agof_repo or config repo URL for HTTPS token" >&2
                 exit 1
               fi
             fi

--- a/values.yaml
+++ b/values.yaml
@@ -19,7 +19,7 @@ agof:
   agof_revision: v2
   # Optional: name of an existing Secret (same namespace) whose keys are mounted for
   # git in the agof-init container (clone agof_repo) and the agof-config container
-  # (e.g. clone/fetch iac_repo during make). Use one of:
+  # (e.g. clone/fetch the config-as-code repo during make). Use one of:
   # - .git-credentials: full git-credential-store line(s) for HTTPS
   # - ssh-privatekey (+ optional known_hosts): SSH private key (e.g. kubernetes.io/ssh-auth)
   # - HTTPS: username + (password or token), or token-only with gitAuthHttpsStyle below
@@ -33,6 +33,9 @@ agof:
   # github|gitlab|gitea: force that platform's usual clone user (git / oauth2 / oauth2)
   gitAuthHttpsStyle: auto
 
+  # Config-as-code repository checked out during configure_aap (cac_* preferred over iac_*)
+  cac_repo: ''
+  cac_revision: ''
   iac_repo: https://github.com/validatedpatterns-demos/ansible-edge-gitops-hmi-config-as-code.git
   iac_revision: main
 


### PR DESCRIPTION
## Summary

- Add optional `agof.cac_repo` / `agof.cac_revision` values (preferred over legacy `iac_repo` / `iac_revision`) with fallback so existing values keep working.
- Extend git credential injection in the init container to cover both AGOF and the config-as-code repo URL.
- Document git authentication Secret shapes (HTTPS, token-only, SSH) in README.
- Release as **v0.2.3** (patch): changes are additive and backward compatible; no breaking chart API changes.

## Test plan

- [ ] `make helm-lint`
- [ ] `make helm-unittest`
- [ ] Confirm existing patterns using `iac_repo` / `iac_revision` render unchanged
- [ ] Confirm optional `cac_repo` / `cac_revision` override works when set


Made with [Cursor](https://cursor.com)