### PR TITLE
Add agof.gitHttpsSslVerify for private-CA HTTPS git clones (v0.2.4)

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -5,7 +5,7 @@ home: https://github.com/validatedpatterns/aap-config-chart.git
 keywords:
 - pattern
 name: aap-config
-version: 0.2.3
+version: 0.2.4
 dependencies:
 - name: vp-rbac
   version: '0.1.*'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aap-config
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square)
 
 A Helm chart to build and deploy secrets using external-secrets for ansible-edge-gitops
 
@@ -39,6 +39,11 @@ instance integration if desired.
 config-as-code repo URL. Requires a compatible AGOF revision (see agof README
 OpenShift section).
 
+* v0.2.4: Add `agof.gitHttpsSslVerify` to disable TLS verification for HTTPS
+git operations when `agof_repo` or the config-as-code repo uses an untrusted or
+private CA (lab use only). Applies to the init-container AGOF clone and is passed
+through to AGOF for the config-as-code checkout.
+
 ### Git authentication secret (`agof.gitAuthSecret`)
 
 When `agof_repo` or the config-as-code repo (`agof.cac_repo` / `agof.iac_repo`) is
@@ -58,6 +63,22 @@ agof:
   # Used only for token-only HTTPS Secrets (see examples)
   gitAuthHttpsStyle: auto   # auto | github | gitlab | gitea
 ```
+
+### HTTPS TLS verification (`agof.gitHttpsSslVerify`)
+
+By default, HTTPS git operations validate the server TLS certificate against the
+container trust store. When `agof_repo` or the config-as-code repo
+(`agof.cac_repo` / `agof.iac_repo`) is served by a host with a private or
+corporate CA that is not installed in the image, set:
+
+```yaml
+agof:
+  gitHttpsSslVerify: false
+```
+
+This disables certificate verification for the init-container clone of AGOF and
+for the config-as-code repo checkout during `configure_aap`. Prefer installing the
+CA in the container image or on the provisioner for production.
 
 #### HTTPS: pre-built `.git-credentials` store
 
@@ -261,6 +282,7 @@ secrets:
 | agof.gitAuthHttpsStyle | string | `"auto"` |  |
 | agof.gitAuthSecret | string | `""` |  |
 | agof.gitAuthVaultKey | string | `""` |  |
+| agof.gitHttpsSslVerify | bool | `true` |  |
 | agof.iac_repo | string | `"https://github.com/validatedpatterns-demos/ansible-edge-gitops-hmi-config-as-code.git"` |  |
 | agof.iac_revision | string | `"main"` |  |
 | agof.vaultFileKey | string | `""` |  |

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -40,6 +40,11 @@ instance integration if desired.
 config-as-code repo URL. Requires a compatible AGOF revision (see agof README
 OpenShift section).
 
+* v0.2.4: Add `agof.gitHttpsSslVerify` to disable TLS verification for HTTPS
+git operations when `agof_repo` or the config-as-code repo uses an untrusted or
+private CA (lab use only). Applies to the init-container AGOF clone and is passed
+through to AGOF for the config-as-code checkout.
+
 ### Git authentication secret (`agof.gitAuthSecret`)
 
 When `agof_repo` or the config-as-code repo (`agof.cac_repo` / `agof.iac_repo`) is
@@ -59,6 +64,22 @@ agof:
   # Used only for token-only HTTPS Secrets (see examples)
   gitAuthHttpsStyle: auto   # auto | github | gitlab | gitea
 ```
+
+### HTTPS TLS verification (`agof.gitHttpsSslVerify`)
+
+By default, HTTPS git operations validate the server TLS certificate against the
+container trust store. When `agof_repo` or the config-as-code repo
+(`agof.cac_repo` / `agof.iac_repo`) is served by a host with a private or
+corporate CA that is not installed in the image, set:
+
+```yaml
+agof:
+  gitHttpsSslVerify: false
+```
+
+This disables certificate verification for the init-container clone of AGOF and
+for the config-as-code repo checkout during `configure_aap`. Prefer installing the
+CA in the container image or on the provisioner for production.
 
 #### HTTPS: pre-built `.git-credentials` store
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -131,8 +131,13 @@ initContainers:
             fi
           fi
 {{- end }}
+{{- if $.Values.agof.gitHttpsSslVerify | default true }}
           git clone --recurse-submodules --single-branch --branch "{{ $.Values.agof.agof_revision }}" \
             -- "$agof_repo_url" /pattern-home/agof_repo
+{{- else }}
+          git -c http.sslVerify=false clone --recurse-submodules --single-branch --branch "{{ $.Values.agof.agof_revision }}" \
+            -- "$agof_repo_url" /pattern-home/agof_repo
+{{- end }}
     volumeMounts:
       - name: agof-scratch-space
         mountPath: /pattern-home

--- a/values.yaml
+++ b/values.yaml
@@ -32,6 +32,9 @@ agof:
   # auto: from each repo URL host (github.com -> git; gitlab / gitea / forgejo / codeberg -> oauth2)
   # github|gitlab|gitea: force that platform's usual clone user (git / oauth2 / oauth2)
   gitAuthHttpsStyle: auto
+  # Verify TLS certificates for HTTPS git clone/fetch (agof-init and AGOF config-repo checkout).
+  # Set to false when agof_repo or the config-as-code repo uses a private CA (lab use only).
+  gitHttpsSslVerify: true
 
   # Config-as-code repository checked out during configure_aap (cac_* preferred over iac_*)
   cac_repo: ''


### PR DESCRIPTION
## Summary
- Add `agof.gitHttpsSslVerify` (default `true`) to disable TLS certificate verification for HTTPS git operations when repos use a private or untrusted CA.
- Apply `git -c http.sslVerify=false clone` in the init container when verification is disabled.
- Pass the setting through Helm values to AGOF for config-as-code checkout during `configure_aap`.
- Release chart version **0.2.4**.

## Related
- Requires a compatible AGOF revision with `agof_config_repo_https_ssl_verify` / OpenShift preinit mapping ([agof PR](https://github.com/mhjacks/agof/compare/aap_27_prep...https-ssl-verify)).

## Test plan
- [ ] Default install: init container clones public `agof_repo` successfully
- [ ] Set `agof.gitHttpsSslVerify: false` and confirm init clone succeeds against an internal Git host with private CA
- [ ] Confirm config-as-code checkout succeeds with the same Helm value when paired with updated AGOF
- [ ] `helm lint` / chart CI pass


Made with [Cursor](https://cursor.com)