### PR TITLE
Read and Normalize to cac_* names in config as well

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -5,7 +5,7 @@ home: https://github.com/validatedpatterns/aap-config-chart.git
 keywords:
 - pattern
 name: aap-config
-version: 0.2.4
+version: 0.2.5
 dependencies:
 - name: vp-rbac
   version: '0.1.*'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aap-config
 
-![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square)
+![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square)
 
 A Helm chart to build and deploy secrets using external-secrets for ansible-edge-gitops
 
@@ -41,14 +41,14 @@ into `cac_*` (and mirrors the result back to `iac_*` for current AGOF releases
 that still read those keys). Requires a compatible AGOF revision (see agof
 README OpenShift section).
 
-* v0.2.5: Fix `helm-values` ConfigMap resolution so `cac_repo` / `cac_revision`
-are the canonical fields. Legacy `iac_*` values merge into `cac_*` when `cac_*`
-is unset; when both are set, `cac_*` wins.
-
 * v0.2.4: Add `agof.gitHttpsSslVerify` to disable TLS verification for HTTPS
 git operations when `agof_repo` or the config-as-code repo uses an untrusted or
 private CA (lab use only). Applies to the init-container AGOF clone and is passed
 through to AGOF for the config-as-code checkout.
+
+* v0.2.5: Fix `helm-values` ConfigMap resolution so `cac_repo` / `cac_revision`
+are the canonical fields. Legacy `iac_*` values merge into `cac_*` when `cac_*`
+is unset; when both are set, `cac_*` wins.
 
 ### Git authentication secret (`agof.gitAuthSecret`)
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,14 @@ instance integration if desired.
 * v0.2.3: Align with AGOF config-as-code naming and git authentication. Add
 `agof.cac_repo` / `agof.cac_revision` (preferred over legacy `iac_repo` /
 `iac_revision`). Git credential injection in init now covers both AGOF and the
-config-as-code repo URL. Requires a compatible AGOF revision (see agof README
-OpenShift section).
+config-as-code repo URL. The `helm-values` ConfigMap resolves legacy `iac_*`
+into `cac_*` (and mirrors the result back to `iac_*` for current AGOF releases
+that still read those keys). Requires a compatible AGOF revision (see agof
+README OpenShift section).
+
+* v0.2.5: Fix `helm-values` ConfigMap resolution so `cac_repo` / `cac_revision`
+are the canonical fields. Legacy `iac_*` values merge into `cac_*` when `cac_*`
+is unset; when both are set, `cac_*` wins.
 
 * v0.2.4: Add `agof.gitHttpsSslVerify` to disable TLS verification for HTTPS
 git operations when `agof_repo` or the config-as-code repo uses an untrusted or
@@ -275,16 +281,16 @@ secrets:
 | agof.agof_repo | string | `"https://github.com/validatedpatterns/agof.git"` |  |
 | agof.agof_revision | string | `"v2"` |  |
 | agof.automationHubTokenKey | string | `"secret/data/hub/automation-hub-token"` |  |
-| agof.cac_repo | string | `""` |  |
-| agof.cac_revision | string | `""` |  |
+| agof.cac_repo | string | `"https://github.com/validatedpatterns-demos/ansible-edge-gitops-hmi-config-as-code.git"` |  |
+| agof.cac_revision | string | `"v2"` |  |
 | agof.doAutoHubVaultConfig | bool | `true` |  |
 | agof.extraPlaybookOpts | string | `""` |  |
 | agof.gitAuthHttpsStyle | string | `"auto"` |  |
 | agof.gitAuthSecret | string | `""` |  |
 | agof.gitAuthVaultKey | string | `""` |  |
 | agof.gitHttpsSslVerify | bool | `true` |  |
-| agof.iac_repo | string | `"https://github.com/validatedpatterns-demos/ansible-edge-gitops-hmi-config-as-code.git"` |  |
-| agof.iac_revision | string | `"main"` |  |
+| agof.iac_repo | string | `""` |  |
+| agof.iac_revision | string | `""` |  |
 | agof.vaultFileKey | string | `""` |  |
 | configJob.activeDeadlineSeconds | int | `3600` |  |
 | configJob.configTimeout | int | `1800` |  |

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ secrets:
 |-----|------|---------|-------------|
 | aapManifest.key | string | `"secret/data/hub/aap-manifest"` |  |
 | agof.agof_repo | string | `"https://github.com/validatedpatterns/agof.git"` |  |
-| agof.agof_revision | string | `"v2"` |  |
+| agof.agof_revision | string | `"main"` |  |
 | agof.automationHubTokenKey | string | `"secret/data/hub/automation-hub-token"` |  |
 | agof.cac_repo | string | `"https://github.com/validatedpatterns-demos/ansible-edge-gitops-hmi-config-as-code.git"` |  |
 | agof.cac_revision | string | `"v2"` |  |

--- a/README.md
+++ b/README.md
@@ -280,10 +280,10 @@ secrets:
 |-----|------|---------|-------------|
 | aapManifest.key | string | `"secret/data/hub/aap-manifest"` |  |
 | agof.agof_repo | string | `"https://github.com/validatedpatterns/agof.git"` |  |
-| agof.agof_revision | string | `"main"` |  |
+| agof.agof_revision | string | `"v2"` |  |
 | agof.automationHubTokenKey | string | `"secret/data/hub/automation-hub-token"` |  |
 | agof.cac_repo | string | `"https://github.com/validatedpatterns-demos/ansible-edge-gitops-hmi-config-as-code.git"` |  |
-| agof.cac_revision | string | `"v2"` |  |
+| agof.cac_revision | string | `"main"` |  |
 | agof.doAutoHubVaultConfig | bool | `true` |  |
 | agof.extraPlaybookOpts | string | `""` |  |
 | agof.gitAuthHttpsStyle | string | `"auto"` |  |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ through to AGOF for the config-as-code checkout.
 
 * v0.2.5: Fix `helm-values` ConfigMap resolution so `cac_repo` / `cac_revision`
 are the canonical fields. Legacy `iac_*` values merge into `cac_*` when `cac_*`
-is unset; when both are set, `cac_*` wins.
+is unset or left at chart defaults; when `cac_*` is explicitly set, it wins over
+`iac_*`.
 
 ### Git authentication secret (`agof.gitAuthSecret`)
 

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -42,14 +42,14 @@ into `cac_*` (and mirrors the result back to `iac_*` for current AGOF releases
 that still read those keys). Requires a compatible AGOF revision (see agof
 README OpenShift section).
 
-* v0.2.5: Fix `helm-values` ConfigMap resolution so `cac_repo` / `cac_revision`
-are the canonical fields. Legacy `iac_*` values merge into `cac_*` when `cac_*`
-is unset; when both are set, `cac_*` wins.
-
 * v0.2.4: Add `agof.gitHttpsSslVerify` to disable TLS verification for HTTPS
 git operations when `agof_repo` or the config-as-code repo uses an untrusted or
 private CA (lab use only). Applies to the init-container AGOF clone and is passed
 through to AGOF for the config-as-code checkout.
+
+* v0.2.5: Fix `helm-values` ConfigMap resolution so `cac_repo` / `cac_revision`
+are the canonical fields. Legacy `iac_*` values merge into `cac_*` when `cac_*`
+is unset; when both are set, `cac_*` wins.
 
 ### Git authentication secret (`agof.gitAuthSecret`)
 

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -49,7 +49,8 @@ through to AGOF for the config-as-code checkout.
 
 * v0.2.5: Fix `helm-values` ConfigMap resolution so `cac_repo` / `cac_revision`
 are the canonical fields. Legacy `iac_*` values merge into `cac_*` when `cac_*`
-is unset; when both are set, `cac_*` wins.
+is unset or left at chart defaults; when `cac_*` is explicitly set, it wins over
+`iac_*`.
 
 ### Git authentication secret (`agof.gitAuthSecret`)
 

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -37,8 +37,14 @@ instance integration if desired.
 * v0.2.3: Align with AGOF config-as-code naming and git authentication. Add
 `agof.cac_repo` / `agof.cac_revision` (preferred over legacy `iac_repo` /
 `iac_revision`). Git credential injection in init now covers both AGOF and the
-config-as-code repo URL. Requires a compatible AGOF revision (see agof README
-OpenShift section).
+config-as-code repo URL. The `helm-values` ConfigMap resolves legacy `iac_*`
+into `cac_*` (and mirrors the result back to `iac_*` for current AGOF releases
+that still read those keys). Requires a compatible AGOF revision (see agof
+README OpenShift section).
+
+* v0.2.5: Fix `helm-values` ConfigMap resolution so `cac_repo` / `cac_revision`
+are the canonical fields. Legacy `iac_*` values merge into `cac_*` when `cac_*`
+is unset; when both are set, `cac_*` wins.
 
 * v0.2.4: Add `agof.gitHttpsSslVerify` to disable TLS verification for HTTPS
 git operations when `agof_repo` or the config-as-code repo uses an untrusted or

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1,3 +1,11 @@
+{{- define "aap-config.agof.configRepo" -}}
+{{- .Values.agof.cac_repo | default .Values.agof.iac_repo -}}
+{{- end -}}
+
+{{- define "aap-config.agof.configRevision" -}}
+{{- .Values.agof.cac_revision | default .Values.agof.iac_revision -}}
+{{- end -}}
+
 {{- define "aap-config.app.configjobspec" -}}
 restartPolicy: Never
 serviceAccountName: {{ $.Values.serviceAccountName }}
@@ -30,7 +38,7 @@ initContainers:
           set -euo pipefail
           export GIT_TERMINAL_PROMPT=0
           agof_repo_url={{ $.Values.agof.agof_repo | quote }}
-          config_repo_url={{ $.Values.agof.cac_repo | default $.Values.agof.iac_repo | quote }}
+          config_repo_url={{ include "aap-config.agof.configRepo" $ | quote }}
 {{- if $.Values.agof.vaultFileKey }}
           base64 -d /pattern-home/agof-vault-file/agof-vault-file > ~/agof_vault.yml
 {{- else }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1,9 +1,35 @@
+{{- define "aap-config.agof.defaultCacRepo" -}}
+{{- "https://github.com/validatedpatterns-demos/ansible-edge-gitops-hmi-config-as-code.git" -}}
+{{- end -}}
+
+{{- define "aap-config.agof.defaultCacRevision" -}}
+{{- "v2" -}}
+{{- end -}}
+
 {{- define "aap-config.agof.configRepo" -}}
-{{- .Values.agof.cac_repo | default .Values.agof.iac_repo -}}
+{{- $cac := .Values.agof.cac_repo -}}
+{{- $iac := .Values.agof.iac_repo -}}
+{{- $default := include "aap-config.agof.defaultCacRepo" . -}}
+{{- if and $cac (ne $cac $default) -}}
+{{- $cac -}}
+{{- else if $iac -}}
+{{- $iac -}}
+{{- else -}}
+{{- $cac -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "aap-config.agof.configRevision" -}}
-{{- .Values.agof.cac_revision | default .Values.agof.iac_revision -}}
+{{- $cac := .Values.agof.cac_revision -}}
+{{- $iac := .Values.agof.iac_revision -}}
+{{- $default := include "aap-config.agof.defaultCacRevision" . -}}
+{{- if and $cac (ne $cac $default) -}}
+{{- $cac -}}
+{{- else if $iac -}}
+{{- $iac -}}
+{{- else -}}
+{{- $cac -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "aap-config.app.configjobspec" -}}

--- a/templates/helm-values-cm.yaml
+++ b/templates/helm-values-cm.yaml
@@ -1,4 +1,13 @@
-{{- $valuesyaml := toYaml $.Values -}} # E: syntax error: expected '<document start>', but found '{'
+{{- $values := deepCopy $.Values -}}
+{{- if $values.agof -}}
+{{- $configRepo := include "aap-config.agof.configRepo" $ -}}
+{{- $configRevision := include "aap-config.agof.configRevision" $ -}}
+{{- $_ := set $values.agof "cac_repo" $configRepo -}}
+{{- $_ := set $values.agof "cac_revision" $configRevision -}}
+{{- $_ := set $values.agof "iac_repo" $configRepo -}}
+{{- $_ := set $values.agof "iac_revision" $configRevision -}}
+{{- end -}}
+{{- $valuesyaml := toYaml $values -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/tests/helm-values-cm_test.yaml
+++ b/tests/helm-values-cm_test.yaml
@@ -46,3 +46,22 @@ tests:
       - matchRegex:
           path: data["values.yaml"]
           pattern: 'iac_revision: main'
+
+  - it: resolves legacy iac values when cac values are left at chart defaults
+    set:
+      agof:
+        iac_repo: https://github.com/example/iac.git
+        iac_revision: main
+    asserts:
+      - matchRegex:
+          path: data["values.yaml"]
+          pattern: 'cac_repo: https://github.com/example/iac.git'
+      - matchRegex:
+          path: data["values.yaml"]
+          pattern: 'cac_revision: main'
+      - matchRegex:
+          path: data["values.yaml"]
+          pattern: 'iac_repo: https://github.com/example/iac.git'
+      - matchRegex:
+          path: data["values.yaml"]
+          pattern: 'iac_revision: main'

--- a/tests/helm-values-cm_test.yaml
+++ b/tests/helm-values-cm_test.yaml
@@ -1,0 +1,48 @@
+---
+suite: helm-values ConfigMap
+templates:
+  - helm-values-cm.yaml
+tests:
+  - it: prefers cac_repo and cac_revision and mirrors them for legacy AGOF fields
+    set:
+      agof:
+        cac_repo: https://github.com/example/cac.git
+        cac_revision: v21_to_be
+        iac_repo: https://github.com/example/iac.git
+        iac_revision: main
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["values.yaml"]
+          pattern: 'cac_repo: https://github.com/example/cac.git'
+      - matchRegex:
+          path: data["values.yaml"]
+          pattern: 'cac_revision: v21_to_be'
+      - matchRegex:
+          path: data["values.yaml"]
+          pattern: 'iac_repo: https://github.com/example/cac.git'
+      - matchRegex:
+          path: data["values.yaml"]
+          pattern: 'iac_revision: v21_to_be'
+
+  - it: resolves legacy iac values into cac fields when cac values are empty
+    set:
+      agof:
+        cac_repo: ""
+        cac_revision: ""
+        iac_repo: https://github.com/example/iac.git
+        iac_revision: main
+    asserts:
+      - matchRegex:
+          path: data["values.yaml"]
+          pattern: 'cac_repo: https://github.com/example/iac.git'
+      - matchRegex:
+          path: data["values.yaml"]
+          pattern: 'cac_revision: main'
+      - matchRegex:
+          path: data["values.yaml"]
+          pattern: 'iac_repo: https://github.com/example/iac.git'
+      - matchRegex:
+          path: data["values.yaml"]
+          pattern: 'iac_revision: main'

--- a/values.yaml
+++ b/values.yaml
@@ -36,11 +36,12 @@ agof:
   # Set to false when agof_repo or the config-as-code repo uses a private CA (lab use only).
   gitHttpsSslVerify: true
 
-  # Config-as-code repository checked out during configure_aap (cac_* preferred over iac_*)
-  cac_repo: ''
-  cac_revision: ''
-  iac_repo: https://github.com/validatedpatterns-demos/ansible-edge-gitops-hmi-config-as-code.git
-  iac_revision: main
+  # Config-as-code repository checked out during configure_aap (cac_* preferred; legacy
+  # iac_* is merged into cac_* when writing the helm-values ConfigMap)
+  cac_repo: https://github.com/validatedpatterns-demos/ansible-edge-gitops-hmi-config-as-code.git
+  cac_revision: v2
+  iac_repo: ''
+  iac_revision: ''
 
 configJob:
   image: quay.io/hybridcloudpatterns/imperative-container:v1

--- a/values.yaml
+++ b/values.yaml
@@ -16,7 +16,7 @@ agof:
   extraPlaybookOpts: ''
 
   agof_repo: https://github.com/validatedpatterns/agof.git
-  agof_revision: main
+  agof_revision: v2
   # Optional: name of an existing Secret (same namespace) whose keys are mounted for
   # git in the agof-init container (clone agof_repo) and the agof-config container
   # (e.g. clone/fetch the config-as-code repo during make). Use one of:
@@ -39,7 +39,7 @@ agof:
   # Config-as-code repository checked out during configure_aap (cac_* preferred; legacy
   # iac_* is merged into cac_* when cac_* is empty or still at chart defaults)
   cac_repo: https://github.com/validatedpatterns-demos/ansible-edge-gitops-hmi-config-as-code.git
-  cac_revision: v2
+  cac_revision: main
   iac_repo: ''
   iac_revision: ''
 

--- a/values.yaml
+++ b/values.yaml
@@ -37,7 +37,7 @@ agof:
   gitHttpsSslVerify: true
 
   # Config-as-code repository checked out during configure_aap (cac_* preferred; legacy
-  # iac_* is merged into cac_* when writing the helm-values ConfigMap)
+  # iac_* is merged into cac_* when cac_* is empty or still at chart defaults)
   cac_repo: https://github.com/validatedpatterns-demos/ansible-edge-gitops-hmi-config-as-code.git
   cac_revision: v2
   iac_repo: ''

--- a/values.yaml
+++ b/values.yaml
@@ -16,7 +16,7 @@ agof:
   extraPlaybookOpts: ''
 
   agof_repo: https://github.com/validatedpatterns/agof.git
-  agof_revision: v2
+  agof_revision: main
   # Optional: name of an existing Secret (same namespace) whose keys are mounted for
   # git in the agof-init container (clone agof_repo) and the agof-config container
   # (e.g. clone/fetch the config-as-code repo during make). Use one of:


### PR DESCRIPTION
- **Also handle iac -> cac transition outside of init**

Previously the code ignored cac_* variables outside of init, incorrectly.
Now both variable sets behave correctly, and the results are normalized.

- **Move note to correct place**

Also bump version number for publication.
