### PR TITLE
Reconfigure retry logic to tolerate slower regions

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -5,7 +5,7 @@ home: https://github.com/validatedpatterns/aap-config-chart.git
 keywords:
 - pattern
 name: aap-config
-version: 0.2.6
+version: 0.2.7
 dependencies:
 - name: vp-rbac
   version: '0.1.*'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aap-config
 
-![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square)
+![Version: 0.2.7](https://img.shields.io/badge/Version-0.2.7-informational?style=flat-square)
 
 A Helm chart to build and deploy secrets using external-secrets for ansible-edge-gitops
 
@@ -52,6 +52,9 @@ is unset or left at chart defaults; when `cac_*` is explicitly set, it wins over
 `iac_*`.
 
 * v0.2.6: Track v3 of AGOF by default
+
+* v0.2.7: Reconfigure how retries are done. Include configurable backoffLimit (default
+20) and reduce activeDeadline seconds to 600 (10 min).
 
 ### Git authentication secret (`agof.gitAuthSecret`)
 

--- a/README.md
+++ b/README.md
@@ -295,7 +295,8 @@ secrets:
 | agof.iac_repo | string | `""` |  |
 | agof.iac_revision | string | `""` |  |
 | agof.vaultFileKey | string | `""` |  |
-| configJob.activeDeadlineSeconds | int | `3600` |  |
+| configJob.activeDeadlineSeconds | int | `600` |  |
+| configJob.backoffLimit | int | `20` |  |
 | configJob.configTimeout | int | `1800` |  |
 | configJob.image | string | `"quay.io/hybridcloudpatterns/imperative-container:v1"` |  |
 | configJob.imagePullPolicy | string | `"Always"` |  |

--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ is unset or left at chart defaults; when `cac_*` is explicitly set, it wins over
 
 * v0.2.6: Track v3 of AGOF by default
 
-* v0.2.7: Reconfigure how retries are done. Include configurable backoffLimit (default
-20) and reduce activeDeadline seconds to 600 (10 min).
+* v0.2.7: Reconfigure external secrets validation retries. Add configurable
+`validationJob.backoffLimit` (default 20) and reduce `validationJob.activeDeadlineSeconds`
+to 600 (10 min) so slow ESO sync gets more frequent job-level retries.
 
 ### Git authentication secret (`agof.gitAuthSecret`)
 
@@ -298,8 +299,7 @@ secrets:
 | agof.iac_repo | string | `""` |  |
 | agof.iac_revision | string | `""` |  |
 | agof.vaultFileKey | string | `""` |  |
-| configJob.activeDeadlineSeconds | int | `600` |  |
-| configJob.backoffLimit | int | `20` |  |
+| configJob.activeDeadlineSeconds | int | `3600` |  |
 | configJob.configTimeout | int | `1800` |  |
 | configJob.image | string | `"quay.io/hybridcloudpatterns/imperative-container:v1"` |  |
 | configJob.imagePullPolicy | string | `"Always"` |  |
@@ -308,7 +308,8 @@ secrets:
 | secretStore.name | string | `"vault-backend"` |  |
 | serviceAccountName | string | `"aap-config-sa"` |  |
 | serviceAccountNamespace | string | `"aap-config"` |  |
-| validationJob.activeDeadlineSeconds | int | `3600` |  |
+| validationJob.activeDeadlineSeconds | int | `600` |  |
+| validationJob.backoffLimit | int | `20` |  |
 | validationJob.disabled | bool | `false` |  |
 | vp-rbac.clusterRoles.view-routes.rules[0].apiGroups[0] | string | `"route.openshift.io"` |  |
 | vp-rbac.clusterRoles.view-routes.rules[0].resources[0] | string | `"routes"` |  |

--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ is unset or left at chart defaults; when `cac_*` is explicitly set, it wins over
 
 * v0.2.7: Reconfigure external secrets validation retries. Add configurable
 `validationJob.backoffLimit` (default 20) and reduce `validationJob.activeDeadlineSeconds`
-to 600 (10 min) so slow ESO sync gets more frequent job-level retries.
+to 600 (10 min). Run the validation job as an Argo Sync hook at sync-wave 2 with
+`HookSucceeded,BeforeHookCreation` so ExternalSecrets apply in wave 1 before
+validation runs and each sync retry gets a fresh job without OutOfSync drift.
 
 ### Git authentication secret (`agof.gitAuthSecret`)
 

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -54,8 +54,9 @@ is unset or left at chart defaults; when `cac_*` is explicitly set, it wins over
 
 * v0.2.6: Track v3 of AGOF by default
 
-* v0.2.7: Reconfigure how retries are done. Include configurable backoffLimit (default
-20) and reduce activeDeadline seconds to 600 (10 min).
+* v0.2.7: Reconfigure external secrets validation retries. Add configurable
+`validationJob.backoffLimit` (default 20) and reduce `validationJob.activeDeadlineSeconds`
+to 600 (10 min) so slow ESO sync gets more frequent job-level retries.
 
 ### Git authentication secret (`agof.gitAuthSecret`)
 

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -56,7 +56,9 @@ is unset or left at chart defaults; when `cac_*` is explicitly set, it wins over
 
 * v0.2.7: Reconfigure external secrets validation retries. Add configurable
 `validationJob.backoffLimit` (default 20) and reduce `validationJob.activeDeadlineSeconds`
-to 600 (10 min) so slow ESO sync gets more frequent job-level retries.
+to 600 (10 min). Run the validation job as an Argo Sync hook at sync-wave 2 with
+`HookSucceeded,BeforeHookCreation` so ExternalSecrets apply in wave 1 before
+validation runs and each sync retry gets a fresh job without OutOfSync drift.
 
 ### Git authentication secret (`agof.gitAuthSecret`)
 

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -54,6 +54,9 @@ is unset or left at chart defaults; when `cac_*` is explicitly set, it wins over
 
 * v0.2.6: Track v3 of AGOF by default
 
+* v0.2.7: Reconfigure how retries are done. Include configurable backoffLimit (default
+20) and reduce activeDeadline seconds to 600 (10 min).
+
 ### Git authentication secret (`agof.gitAuthSecret`)
 
 When `agof_repo` or the config-as-code repo (`agof.cac_repo` / `agof.iac_repo`) is

--- a/templates/agof-config-bootstrap-job.yaml
+++ b/templates/agof-config-bootstrap-job.yaml
@@ -12,6 +12,7 @@ spec:
   backoffLimit: 99
   template:
     spec:
+      backoffLimit: {{ $.Values.configJob.backoffLimit }}
       activeDeadlineSeconds: {{ $.Values.configJob.activeDeadlineSeconds }}
       {{- include "aap-config.app.configjobspec" $ | nindent 6 }}
 {{- end }}{{/* if not $.Values.configJob.disabled */}}

--- a/templates/agof-config-bootstrap-job.yaml
+++ b/templates/agof-config-bootstrap-job.yaml
@@ -5,7 +5,7 @@ kind: Job
 metadata:
   name: agof-config-bootstrap-job
   annotations:
-    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-wave: "3"
 spec:
   parallelism: 1
   completions: 1

--- a/templates/agof-config-bootstrap-job.yaml
+++ b/templates/agof-config-bootstrap-job.yaml
@@ -12,7 +12,6 @@ spec:
   backoffLimit: 99
   template:
     spec:
-      backoffLimit: {{ $.Values.configJob.backoffLimit }}
       activeDeadlineSeconds: {{ $.Values.configJob.activeDeadlineSeconds }}
       {{- include "aap-config.app.configjobspec" $ | nindent 6 }}
 {{- end }}{{/* if not $.Values.configJob.disabled */}}

--- a/templates/external-secrets-validation-job.yaml
+++ b/templates/external-secrets-validation-job.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   parallelism: 1
   completions: 1
-  backoffLimit: 3
+  backoffLimit: {{ $.Values.validationJob.backoffLimit }}
   activeDeadlineSeconds: {{ $.Values.validationJob.activeDeadlineSeconds }}
   template:
     spec:

--- a/templates/external-secrets-validation-job.yaml
+++ b/templates/external-secrets-validation-job.yaml
@@ -5,7 +5,9 @@ kind: Job
 metadata:
   name: external-secrets-validation-job
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded,BeforeHookCreation
 spec:
   parallelism: 1
   completions: 1

--- a/values.yaml
+++ b/values.yaml
@@ -46,8 +46,7 @@ agof:
 configJob:
   image: quay.io/hybridcloudpatterns/imperative-container:v1
   schedule: "10 */2 * * *"
-  activeDeadlineSeconds: 600
-  backoffLimit: 20
+  activeDeadlineSeconds: 3600
   imagePullPolicy: Always
   configTimeout: 1800
 
@@ -57,7 +56,8 @@ serviceAccountNamespace: aap-config
 # Validation job configuration
 validationJob:
   disabled: false
-  activeDeadlineSeconds: 3600
+  activeDeadlineSeconds: 600
+  backoffLimit: 20
 
 # RBAC configuration using vp-rbac subchart
 vp-rbac:

--- a/values.yaml
+++ b/values.yaml
@@ -46,7 +46,8 @@ agof:
 configJob:
   image: quay.io/hybridcloudpatterns/imperative-container:v1
   schedule: "10 */2 * * *"
-  activeDeadlineSeconds: 3600
+  activeDeadlineSeconds: 600
+  backoffLimit: 20
   imagePullPolicy: Always
   configTimeout: 1800
 


### PR DESCRIPTION
Broadly, this re-orders sync-waves and changes handling to ensure ES's are synced before validation.
Previously, they were in the same wave as validation which could race and prevent the ES's from ever
syncing. This also adds deletion to the validation job so that it will self-delete if it needs to run
again and not show as an out-of-sync resource.
